### PR TITLE
Timestamp does not match response format

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -11,7 +11,7 @@ use AdamAveray\Typeform\Utils\Refs;
  */
 abstract class Model
 {
-  private const TIMESTAMP_FORMAT = 'Y-m-d\\TH:i:s.u\\Z';
+  private const TIMESTAMP_FORMAT = 'Y-m-d\\TH:i:s\\Z';
 
   public string $id;
   public array $rawData;


### PR DESCRIPTION
I was getting "Invalid timestamp" exception when fetching responses